### PR TITLE
Make Key.h less likely to conflict with other libs

### DIFF
--- a/src/Key.h
+++ b/src/Key.h
@@ -29,8 +29,8 @@
 ||
 */
 
-#ifndef KEY_H
-#define KEY_H
+#ifndef Keypadlib_KEY_H_
+#define Keypadlib_KEY_H_
 
 #include <Arduino.h>
 


### PR DESCRIPTION
Some other libs, particularly for USB keyboard support, define "KEY_H".

This very simple change avoids those conflicts by making Keypad's #define more unique.