### PR TITLE
Fix glitching behavior on Teensy 3.2

### DIFF
--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -94,8 +94,7 @@ void Keypad::scanKeys() {
 			bitWrite(bitMap[r], c, !pin_read(rowPins[r]));  // keypress is active low so invert to high.
 		}
 		// Set pin to high impedance input. Effectively ends column pulse.
-		pin_write(columnPins[c],HIGH);
-		pin_mode(columnPins[c],INPUT);
+		pin_mode(columnPins[c],INPUT_PULLUP);
 	}
 }
 


### PR DESCRIPTION
The pin_write HIGH followed by  pin_mode INPUT results in a glitching button matrix on the Teensy 3.2 and possibly other microcontrollers. Replacing these two lines with one pin_mode INPUT_PULLUP solves the issue.