### PR TITLE
Fix broken markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Keypad library for Arduino
 
-**Authors:**  *Mark Stanley***,** *Alexander Brevig*
+**Authors:**  *Mark Stanley*__,__ *Alexander Brevig*
 
 
 This repository is a copy of the code found here [[Arduino Playground]](http://playground.arduino.cc/Code/Keypad).


### PR DESCRIPTION
GitHub has recently changed their Markdown interpreter to strictly follow the [GFM spec](https://github.github.com/gfm). This has broken some Markdown that worked previously. By alternating the delimiters used this problem is fixed while retaining the previous formatting of emphasis on the names and strong emphasis on the comma.

README.md as it currently renders:
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/24826500/450bb2fc-1bec-11e7-87a3-a2fc576063e9.png)
