### PR TITLE
Update for STM32 boards

### DIFF
--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -37,20 +37,6 @@
 
 // bperrybap - Thanks for a well reasoned argument and the following macro(s).
 // See http://arduino.cc/forum/index.php/topic,142041.msg1069480.html#msg1069480
-#ifndef INPUT_PULLUP
-#warning "Using  pinMode() INPUT_PULLUP AVR emulation"
-#define INPUT_PULLUP 0x2
-#define pinMode(_pin, _mode) _mypinMode(_pin, _mode)
-#define _mypinMode(_pin, _mode)  \
-do {							 \
-	if(_mode == INPUT_PULLUP)	 \
-		pinMode(_pin, INPUT);	 \
-		digitalWrite(_pin, 1);	 \
-	if(_mode != INPUT_PULLUP)	 \
-		pinMode(_pin, _mode);	 \
-}while(0)
-#endif
-
 
 #define OPEN LOW
 #define CLOSED HIGH
@@ -75,11 +61,7 @@ typedef struct {
 class Keypad : public Key {
 public:
 
-	Keypad(char *userKeymap, byte *row, byte *col, byte numRows, byte numCols);
-
-	virtual void pin_mode(byte pinNum, byte mode) { pinMode(pinNum, mode); }
-	virtual void pin_write(byte pinNum, boolean level) { digitalWrite(pinNum, level); }
-	virtual int  pin_read(byte pinNum) { return digitalRead(pinNum); }
+	Keypad(char *userKeymap, int *row, int *col, byte numRows, byte numCols);
 
 	uint bitMap[MAPSIZE];	// 10 row x 16 column array of bits. Except Due which has 32 columns.
 	Key key[LIST_MAX];
@@ -102,8 +84,8 @@ public:
 private:
 	unsigned long startTime;
 	char *keymap;
-    byte *rowPins;
-    byte *columnPins;
+    int *rowPins;
+    int *columnPins;
 	KeypadSize sizeKpd;
 	uint debounceTime;
 	uint holdTime;


### PR DESCRIPTION
With these changes it is possible to use the library on STM32 cards because the pins are named and unnumbered and the Virtual Voids only handled Byte pins, this generated error in the compilation, I am not programming expert but this change worked well for me and not affected operation on the Arduino boards.