### PR TITLE
Allow more rows to be used in the keypad

### DIFF
--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -67,7 +67,7 @@ typedef struct {
 } KeypadSize;
 
 #define LIST_MAX 10		// Max number of keys on the active list.
-#define MAPSIZE 10		// MAPSIZE is the number of rows (times 16 columns)
+#define MAPSIZE 12		// MAPSIZE is the number of rows (times 16 columns)
 #define makeKeymap(x) ((char*)x)
 
 

--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -81,7 +81,7 @@ public:
 	virtual void pin_write(byte pinNum, boolean level) { digitalWrite(pinNum, level); }
 	virtual int  pin_read(byte pinNum) { return digitalRead(pinNum); }
 
-	uint bitMap[MAPSIZE];	// 10 row x 16 column array of bits. Except Due which has 32 columns.
+	uint bitMap[MAPSIZE];	// 12 row x 16 column array of bits. Except Due which has 32 columns.
 	Key key[LIST_MAX];
 	unsigned long holdTimer;
 


### PR DESCRIPTION
If your keypad matrix has more than 10 rows there will be scanning issues. Raising MAPSIZE to 12 allows for two more rows to be used. Theoretically the maximum number of rows should be 16, accounting for 256 possible key values. take into account than with big keyboards is not always possible to use only 10 rows, i.e, a 140 keys keypad coulb be necessary to be designed with 12 columns x12 rows or 13 columnsx13 rows rather than 14x10 column