### PR TITLE
Aliases OPEN and CLOSED are causing compatibility issues with another libraries

### DIFF
--- a/src/Key.h
+++ b/src/Key.h
@@ -34,8 +34,8 @@
 
 #include <Arduino.h>
 
-#define OPEN LOW
-#define CLOSED HIGH
+#define KEYPAD_OPEN LOW
+#define KEYPAD_CLOSED HIGH
 
 typedef unsigned int uint;
 typedef enum{ IDLE, PRESSED, HOLD, RELEASED } KeyState;

--- a/src/Keypad.cpp
+++ b/src/Keypad.cpp
@@ -154,18 +154,18 @@ void Keypad::nextKeyState(byte idx, boolean button) {
 
 	switch (key[idx].kstate) {
 		case IDLE:
-			if (button==CLOSED) {
+			if (button==KEYPAD_CLOSED) {
 				transitionTo (idx, PRESSED);
 				holdTimer = millis(); }		// Get ready for next HOLD state.
 			break;
 		case PRESSED:
 			if ((millis()-holdTimer)>holdTime)	// Waiting for a key HOLD...
 				transitionTo (idx, HOLD);
-			else if (button==OPEN)				// or for a key to be RELEASED.
+			else if (button==KEYPAD_OPEN)				// or for a key to be RELEASED.
 				transitionTo (idx, RELEASED);
 			break;
 		case HOLD:
-			if (button==OPEN)
+			if (button==KEYPAD_OPEN)
 				transitionTo (idx, RELEASED);
 			break;
 		case RELEASED:

--- a/src/Keypad.h
+++ b/src/Keypad.h
@@ -52,8 +52,8 @@ do {							 \
 #endif
 
 
-#define OPEN LOW
-#define CLOSED HIGH
+#define KEYPAD_OPEN LOW    // Many libraries use this alias OPEN , and this cause issues
+#define KEYPAD_CLOSED HIGH  // Many libraries use this alias CLOSED , and this cause issues
 
 typedef char KeypadEvent;
 typedef unsigned int uint;


### PR DESCRIPTION
I've made a gross change to the OPEN and CLOSED aliases in the Key.h, Keypad.h, and Keypad files.cpp because this is causing some incompatibilities with other libraries, because duplicate and inconsistent definitions happen. It took me a long time to realize that this was the problem.